### PR TITLE
Adds an accessibility value to item rows, indicating priority/completion

### DIFF
--- a/SimpleToDo/SimpleToDo/ItemRow.swift
+++ b/SimpleToDo/SimpleToDo/ItemRow.swift
@@ -24,6 +24,7 @@ struct ItemRow: View {
                 .animation(nil, value: item)
         }
         .tag(item)
+        .accessibilityValue(item.accessibilityValue)
     }
 }
 

--- a/SimpleToDo/SimpleToDo/ToDoItem.swift
+++ b/SimpleToDo/SimpleToDo/ToDoItem.swift
@@ -48,6 +48,22 @@ struct ToDoItem: Codable, Identifiable, Hashable {
         }
     }
 
+    /// The value of the item, to convey this information to assistive technologies.
+    var accessibilityValue: String {
+        if isComplete {
+            return "completed"
+        } else {
+            switch priority {
+            case .low:
+                return "low priority"
+            case .medium:
+                return "medium priority"
+            case .high:
+                return "high priority"
+            }
+        }
+    }
+
     /// An example property that's used for Xcode previewing.
     static let example = ToDoItem()
 }

--- a/SimpleToDo/SimpleToDo/ToDoItem.swift
+++ b/SimpleToDo/SimpleToDo/ToDoItem.swift
@@ -57,7 +57,7 @@ struct ToDoItem: Codable, Identifiable, Hashable {
             case .low:
                 return "low priority"
             case .medium:
-                return "medium priority"
+                return "" // To prevent verbosity, don't set a specific value for the default priority.
             case .high:
                 return "high priority"
             }


### PR DESCRIPTION
Hi!

This change adds an accessibility value to the item rows for todo-items, indicating their status.
This helps users using an assistive technology have a better overview of an item, not requiring to go into the details to figure out an item's status.

| Before | After |
| - | - |
| <img width="539" alt="before" src="https://user-images.githubusercontent.com/4190298/166303668-a57950ae-a8b5-4ea5-9348-001c720bcfdb.png"> | <img width="539" alt="after" src="https://user-images.githubusercontent.com/4190298/166303663-bc8fb59f-c144-4446-9adb-f53202c483c2.png"> |