### PR TITLE
Add FileHeader template to the two projects

### DIFF
--- a/SimpleScores/SimpleScores.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/SimpleScores/SimpleScores.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string> Copyright © ___YEAR___ Paul Hudson.
+//
+// https://github.com/twostraws/simple-swiftui
+// See LICENSE for license information
+//</string>
+</dict>
+</plist>

--- a/SimpleToDo/SimpleToDo.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/SimpleToDo/SimpleToDo.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string> Copyright © ___YEAR___ Paul Hudson.
+//
+// https://github.com/twostraws/simple-swiftui
+// See LICENSE for license information
+//</string>
+</dict>
+</plist>


### PR DESCRIPTION
This keeps the copyright header at the top of new files consistent.