### PR TITLE
Autocorrect lint errors where possible

### DIFF
--- a/SimpleScores/SimpleScores.xcodeproj/project.pbxproj
+++ b/SimpleScores/SimpleScores.xcodeproj/project.pbxproj
@@ -225,7 +225,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n  swiftlint --fix\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/SimpleScores/SimpleScoresTests/ViewModelTests.swift
+++ b/SimpleScores/SimpleScoresTests/ViewModelTests.swift
@@ -9,32 +9,32 @@ import XCTest
 @testable import SimpleScores
 
 final class ViewModelTests: XCTestCase {
-    
+
     private var sut: ViewModel!
-    
+
     override func setUp() {
         super.setUp()
         sut = ViewModel()
     }
-    
+
     override func tearDown() {
         sut = nil
         super.tearDown()
     }
-    
+
     func testAdd() {
         // The `add()` method should add one new item to the `items` array.
         let initialCount = sut.items.count
         sut.add()
-        
+
         // The result that is expected from the system under test.
         let expectation = initialCount + 1
-        
+
         // Check the actual value against the expected result.
         let result = sut.items.count
         XCTAssertEqual(result, expectation)
     }
-    
+
     func testDelete() {
         // The `delete(_:)` method should delete items from the array for the specified `IndexSet`.
         // Make sure the `items` array has at least one element for testing purposes.
@@ -43,40 +43,40 @@ final class ViewModelTests: XCTestCase {
         let initialCount = sut.items.count
         let indexSet = IndexSet(integer: 0)
         sut.delete(indexSet)
-        
+
         // The result that is expected from the system under test.
         let expectation = initialCount - 1
-        
+
         // Check the actual value against the expected result.
         let result = sut.items.count
         XCTAssertEqual(result, expectation)
     }
-    
+
     func testDeleteAll() {
         // The `deleteAll()` method should delete all items from the `items` array, leaving none behind.
         // Make sure the `items` array has at least one element for testing purposes.
         let item = Score()
         sut.items.append(item)
         sut.deleteAll()
-        
+
         // The result that is expected from the system under test.
         let expectation = 0
-        
+
         // Check the actual value against the expected result.
         let result = sut.items.count
         XCTAssertEqual(result, expectation)
     }
-    
+
     func testReset() {
         // The `reset()` method should set all scores in the `items` array back to zero.
         // Make sure the `items` array has at least one element with non-zero score for testing purposes.
         let item = Score(score: 1)
         sut.items.append(item)
         sut.reset()
-        
+
         // Check the actual value against the expected result.
         let result = sut.items.map(\.score).allSatisfy { $0 == 0 }
         XCTAssertTrue(result)
     }
-    
+
 }

--- a/SimpleToDo/SimpleToDo.xcodeproj/project.pbxproj
+++ b/SimpleToDo/SimpleToDo.xcodeproj/project.pbxproj
@@ -168,7 +168,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n  swiftlint --fix\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Add the `--fix` flag to the SwiftLint script to fix errors where possible. This commit also clears up the errors in the test file