### PR TITLE
Move Preview specific code to a better location

### DIFF
--- a/SimpleScores/SimpleScores.xcodeproj/project.pbxproj
+++ b/SimpleScores/SimpleScores.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		510F435E281DA3220060A05A /* FileManager-DocumentsDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510F435C281DA3220060A05A /* FileManager-DocumentsDirectory.swift */; };
 		510F435F281DA3220060A05A /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510F435D281DA3220060A05A /* ViewModel.swift */; };
 		510F4361281DA3C60060A05A /* ScoreRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510F4360281DA3C60060A05A /* ScoreRow.swift */; };
+		AD975CE128253CE10042EAE4 /* Score+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD975CE028253CE10042EAE4 /* Score+Preview.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -42,6 +43,7 @@
 		510F435C281DA3220060A05A /* FileManager-DocumentsDirectory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileManager-DocumentsDirectory.swift"; sourceTree = "<group>"; };
 		510F435D281DA3220060A05A /* ViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		510F4360281DA3C60060A05A /* ScoreRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreRow.swift; sourceTree = "<group>"; };
+		AD975CE028253CE10042EAE4 /* Score+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Score+Preview.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +110,7 @@
 			isa = PBXGroup;
 			children = (
 				510F4351281DA1720060A05A /* Preview Assets.xcassets */,
+				AD975CE028253CE10042EAE4 /* Score+Preview.swift */,
 			);
 			path = "Preview Content";
 			sourceTree = "<group>";
@@ -249,6 +252,7 @@
 				510F435B281DA2C00060A05A /* Score.swift in Sources */,
 				510F435F281DA3220060A05A /* ViewModel.swift in Sources */,
 				510F434B281DA1710060A05A /* SimpleScoresApp.swift in Sources */,
+				AD975CE128253CE10042EAE4 /* Score+Preview.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SimpleScores/SimpleScores/Preview Content/Score+Preview.swift
+++ b/SimpleScores/SimpleScores/Preview Content/Score+Preview.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// Code in this folder is not included when creating an archive to send to the app store, in the same way that the code for SwifUI Previews are stripped out of archived builds
 extension Score {
     /// An example property that's used for Xcode previewing.
     static let example = Score()

--- a/SimpleScores/SimpleScores/Preview Content/Score+Preview.swift
+++ b/SimpleScores/SimpleScores/Preview Content/Score+Preview.swift
@@ -1,0 +1,13 @@
+// Copyright © 2022 Paul Hudson.
+// Licensed under MIT license.
+//
+// https://github.com/twostraws/simple-swiftui
+// See LICENSE for license information
+//
+
+import Foundation
+
+extension Score {
+    /// An example property that's used for Xcode previewing.
+    static let example = Score()
+}

--- a/SimpleScores/SimpleScores/Score.swift
+++ b/SimpleScores/SimpleScores/Score.swift
@@ -25,7 +25,4 @@ struct Score: Codable, Identifiable, Hashable {
     /// The named color to use for this player's background.
     /// See ColorChoice.swift and the asset catalog for more information.
     var color = ColorChoice.blue
-
-    /// An example property that's used for Xcode previewing.
-    static let example = Score()
 }

--- a/SimpleToDo/SimpleToDo.xcodeproj/project.pbxproj
+++ b/SimpleToDo/SimpleToDo.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		510F4339281D9AAD0060A05A /* SelectSomethingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510F4338281D9AAD0060A05A /* SelectSomethingView.swift */; };
 		510F433B281D9C0C0060A05A /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510F433A281D9C0C0060A05A /* DetailView.swift */; };
 		510F433D281D9D560060A05A /* ItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510F433C281D9D560060A05A /* ItemRow.swift */; };
+		AD975CDF28253BE00042EAE4 /* ToDoItem+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD975CDE28253BE00042EAE4 /* ToDoItem+Preview.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +32,7 @@
 		510F4338281D9AAD0060A05A /* SelectSomethingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectSomethingView.swift; sourceTree = "<group>"; };
 		510F433A281D9C0C0060A05A /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		510F433C281D9D560060A05A /* ItemRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemRow.swift; sourceTree = "<group>"; };
+		AD975CDE28253BE00042EAE4 /* ToDoItem+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ToDoItem+Preview.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +83,7 @@
 			isa = PBXGroup;
 			children = (
 				510F432B281D95BC0060A05A /* Preview Assets.xcassets */,
+				AD975CDE28253BE00042EAE4 /* ToDoItem+Preview.swift */,
 			);
 			path = "Preview Content";
 			sourceTree = "<group>";
@@ -185,6 +188,7 @@
 				510F4335281D97090060A05A /* FileManager-DocumentsDirectory.swift in Sources */,
 				510F4333281D95EA0060A05A /* ToDoItem.swift in Sources */,
 				510F433D281D9D560060A05A /* ItemRow.swift in Sources */,
+				AD975CDF28253BE00042EAE4 /* ToDoItem+Preview.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SimpleToDo/SimpleToDo/Preview Content/ToDoItem+Preview.swift
+++ b/SimpleToDo/SimpleToDo/Preview Content/ToDoItem+Preview.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// Code in this folder is not included when creating an archive to send to the app store, in the same way that the code for SwifUI Previews are stripped out of archived builds
 extension ToDoItem {
     /// An example property that's used for Xcode previewing.
     static let example = ToDoItem()

--- a/SimpleToDo/SimpleToDo/Preview Content/ToDoItem+Preview.swift
+++ b/SimpleToDo/SimpleToDo/Preview Content/ToDoItem+Preview.swift
@@ -1,0 +1,13 @@
+// Copyright © 2022 Paul Hudson.
+// Licensed under MIT license.
+//
+// https://github.com/twostraws/simple-swiftui
+// See LICENSE for license information
+//
+
+import Foundation
+
+extension ToDoItem {
+    /// An example property that's used for Xcode previewing.
+    static let example = ToDoItem()
+}

--- a/SimpleToDo/SimpleToDo/ToDoItem.swift
+++ b/SimpleToDo/SimpleToDo/ToDoItem.swift
@@ -63,7 +63,4 @@ struct ToDoItem: Codable, Identifiable, Hashable {
             }
         }
     }
-
-    /// An example property that's used for Xcode previewing.
-    static let example = ToDoItem()
 }


### PR DESCRIPTION
The Preview Content folder is not just for assets, it's for any code that you want to use only in previews rather than having it compiled in the production code.