### PR TITLE
Fix the issue that the search field is hidden as default is not working in SimpleNews app.

### DIFF
--- a/SimpleNews/SimpleNews/ContentView.swift
+++ b/SimpleNews/SimpleNews/ContentView.swift
@@ -40,6 +40,8 @@ struct ContentView: View {
                 }
             case .success:
                 List(filteredArticles, rowContent: ArticleRow.init)
+					.refreshable(action: downloadArticles)
+					.searchable(text: $searchText)
             case .failed:
                 VStack {
                     Text("Failed to download articles")
@@ -63,8 +65,6 @@ struct ContentView: View {
         }
         .navigationTitle("SimpleNews")
         .task(downloadArticles)
-        .refreshable(action: downloadArticles)
-        .searchable(text: $searchText)
     }
 
     /// Filters the articles array based on the user's search criteria.


### PR DESCRIPTION
In SimpleNews app, I think the reason that the search bar is not hidden at start is `.searchable` is attached to the whole `Group`. I found that moving `.searchable` to `List` makes search bar behaviour appropriately. Likewise, `.refreshable` is not working in loading or failed state. This also should be moved to `List`.