### PR TITLE
Fix UI tests for SimpleScores with existing data

### DIFF
--- a/SimpleScores/SimpleScores/SimpleScoresApp.swift
+++ b/SimpleScores/SimpleScores/SimpleScoresApp.swift
@@ -35,6 +35,11 @@ struct SimpleScoresApp: App {
             if phase == .background {
                 model.save()
             }
+
+            // Clear model data when running UI tests
+            if phase == .active && ProcessInfo.processInfo.arguments.contains("clearAll") {
+                model.deleteAll()
+            }
         }
     }
 }

--- a/SimpleScores/SimpleScoresUITests/SimpleScoresUITests.swift
+++ b/SimpleScores/SimpleScoresUITests/SimpleScoresUITests.swift
@@ -13,6 +13,7 @@ class SimpleScoresUITests: XCTestCase {
         continueAfterFailure = false
 
         app = XCUIApplication()
+        app.launchArguments = ["clearAll"]
         app.launch()
     }
 
@@ -40,6 +41,12 @@ class SimpleScoresUITests: XCTestCase {
         // Action - Tap remove all button and confirm alert
         app.buttons["Remove All"].tap()
         app.alerts.buttons["Delete"].tap()
+
+        // Wait up to 2 seconds for delete to complete and update the UI
+        // The cell "Add Player" is always there so count should be 1 after all players are deleted
+        let countIsOne = NSPredicate(format: "count == 1")
+        expectation(for: countIsOne, evaluatedWith: app.tables.cells, handler: nil)
+        waitForExpectations(timeout: 2, handler: nil)
 
         // Assert - Get the updated amount of player.
         // The cell "Add Player" is always there so subtract 1


### PR DESCRIPTION
This PR addresses UI test failures with existing data.

To replicate test failure of `testAddingNewPlayerWorks`:
- Build and run the app
- Add max number of players (8)
- Background the app to force the view model to save to file
- Run the `testAddingNewPlayerWorks` UI test
- Test fails due to expectation of a new player being added

<img width="1081" alt="Screenshot 2022-08-04 at 18 54 09" src="https://user-images.githubusercontent.com/16542463/182918107-28674b2b-8b98-48ff-9c00-8d9db90e914a.png">

To replicate test failure of `testDeletingAllPlayersWorks`:
- Build and run the app
- Add at least 2 players
- Background the app to force the view model to save to file
- Run the `testDeletingAllPlayersWorks` UI test
- Test fails due to the extra time it takes to animate the deletion of the additional players

<img width="1084" alt="Screenshot 2022-08-04 at 18 56 21" src="https://user-images.githubusercontent.com/16542463/182918482-5c98fdca-8097-4870-afe3-6e1ca9908f46.png">

