### PR TITLE
Update NavigationLink with Hashable value and Navigation Destination modifier to improve performance

### DIFF
--- a/SimpleNews/SimpleNews.xcodeproj/project.pbxproj
+++ b/SimpleNews/SimpleNews.xcodeproj/project.pbxproj
@@ -313,6 +313,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -342,6 +343,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/SimpleNews/SimpleNews/Article.swift
+++ b/SimpleNews/SimpleNews/Article.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// One article in our downloaded data.
-struct Article: Decodable, Identifiable, Comparable {
+struct Article: Decodable, Identifiable, Comparable, Hashable {
     /// The unique identifier string.
     let id: String
 

--- a/SimpleNews/SimpleNews/ArticleRow.swift
+++ b/SimpleNews/SimpleNews/ArticleRow.swift
@@ -11,33 +11,29 @@ import SwiftUI
 struct ArticleRow: View {
     /// The article this row should be showing.
     let article: Article
-
+    
     var body: some View {
-        NavigationLink {
-            ReadingView(article: article)
-        } label: {
-            HStack {
-                AsyncImage(url: article.thumbnail) { phase in
-                    switch phase {
-                    case .empty:
-                        ProgressView()
-                    case .success(let image):
-                        image
-                            .resizable()
-                            .scaledToFill()
-                    default:
-                        Image(systemName: "newspaper")
-                    }
+        HStack {
+            AsyncImage(url: article.thumbnail) { phase in
+                switch phase {
+                case .empty:
+                    ProgressView()
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFill()
+                default:
+                    Image(systemName: "newspaper")
                 }
-                .frame(width: 80, height: 80)
-                .clipped()
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-
-                VStack(alignment: .leading) {
-                    Text(article.section)
-                        .font(.caption.weight(.heavy))
-                    Text(article.title)
-                }
+            }
+            .frame(width: 80, height: 80)
+            .clipped()
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            
+            VStack(alignment: .leading) {
+                Text(article.section)
+                    .font(.caption.weight(.heavy))
+                Text(article.title)
             }
         }
     }

--- a/SimpleNews/SimpleNews/ContentView.swift
+++ b/SimpleNews/SimpleNews/ContentView.swift
@@ -39,9 +39,18 @@ struct ContentView: View {
                     ProgressView()
                 }
             case .success:
-                List(filteredArticles, rowContent: ArticleRow.init)
-					.refreshable(action: downloadArticles)
-					.searchable(text: $searchText)
+                List(filteredArticles) { article in
+                    NavigationLink(value: article) {
+                        // Returns the view for each row or cell
+                        ArticleRow(article: article)
+                    }
+                }
+                .refreshable(action: downloadArticles)
+                .searchable(text: $searchText)
+                .navigationDestination(for: Article.self) { article in
+                    // Returns the detail view which should be shown when a row is tapped
+                    ReadingView(article: article)
+                }
             case .failed:
                 VStack {
                     Text("Failed to download articles")

--- a/SimpleNews/SimpleNews/SimpleNewsApp.swift
+++ b/SimpleNews/SimpleNews/SimpleNewsApp.swift
@@ -12,8 +12,9 @@ import SwiftUI
 struct SimpleNewsApp: App {
     var body: some Scene {
         WindowGroup {
-            NavigationView {
+            NavigationSplitView {
                 ContentView()
+            } detail: {
                 SelectSomethingView()
             }
         }


### PR DESCRIPTION
Improvements:

- Update NavigationLink with Hashable value and Navigation Destination modifier to improve performance (Ref: [Link](https://www.hackingwithswift.com/quick-start/swiftui/displaying-a-detail-screen-with-navigationlink?fbclid=IwAR21C8okgE4wrz_k9vtzYXHEwz4cwRxKR4n7pFiN03SYsUdvFW_oqZr3Riw))
    - In the previous implementation each of the `ReadingView(article)` view would be computed when the  list were created
    - In this implementation the detail view will only be computed when any list item is clicked
- Removed `NavigationView` with updated `NavigationSplitView`(iOS 16.0+) (Tested with both iPad and iPhone)
- Updated the project minimum target to iOS16.0